### PR TITLE
AWS SDK v2 requires to use the bundled cert to work on OSX and other OSs

### DIFF
--- a/kinesis-resharding.rb
+++ b/kinesis-resharding.rb
@@ -2,6 +2,7 @@
 
 require 'aws-sdk'
 
+Aws.use_bundled_cert!
 def has_child_shard(shards,shard_id)
   shards.select{ |s| s[:parent_shard_id] == shard_id}.length > 0
 end

--- a/kinesis-tail.rb
+++ b/kinesis-tail.rb
@@ -2,6 +2,7 @@
 
 require 'aws-sdk'
 
+Aws.use_bundled_cert!
 kinesis = Aws::Kinesis::Client.new
 
 stream_name = ARGV.shift


### PR DESCRIPTION
Quick one line improvement, that allows out of the box use on OS X.
